### PR TITLE
[#7] Upgrade dense encoder from MiniLM to SPECTER2

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ python3 -m src.evaluate --queries data/queries_test.jsonl --top-k 5 --alpha 0.5 
 ### Notes on dense retrieval
 
 - Dense retrieval expects the stored paper embeddings and the query encoder to be consistent.
-- If `data/dense_embeddings_meta.json` is missing, dense and hybrid retrieval will be skipped with a warning.
+- Dense artifacts are now model-specific:
+  - `allenai/specter2_base` -> `data/dense_embeddings_specter2.npy`, `data/dense_embeddings_specter2_meta.json`
+  - `sentence-transformers/all-MiniLM-L6-v2` -> legacy `data/dense_embeddings.npy`, `data/dense_embeddings_meta.json`
+- Use `--dense-model` with `src.retrieval`, `src.evaluate`, or `run_part2.py` to switch between SPECTER2 and MiniLM for ablations.
 - To regenerate dense artifacts and metadata, rerun Part 1:
 
 ```bash
@@ -147,15 +150,17 @@ python3 run_part1.py
 
 ### Current validation results
 
-Using the current validation split (`data/queries_val.jsonl`) with `top-k=10`, the initial paper-level results are:
+Using the current validation split (`data/queries_val.jsonl`) with `top-k=10` and `dense-candidates=100`, the current paper-level results are:
 
 | Method | Precision@10 | Recall@10 | NDCG@10 | MAP |
 | ------ | ------------ | --------- | ------- | --- |
-| TF-IDF | 0.5500 | 1.0000 | 0.8554 | 0.7523 |
-| Dense | 0.0500 | 0.1250 | 0.0588 | 0.0139 |
-| Hybrid | 0.2000 | 0.4464 | 0.4248 | 0.3115 |
+| TF-IDF | 0.4421 | 0.1957 | 0.4452 | 0.1131 |
+| Dense (MiniLM) | 0.5105 | 0.2334 | 0.5275 | 0.1498 |
+| Hybrid (MiniLM) | 0.5263 | 0.2441 | 0.5515 | 0.1642 |
+| Dense (SPECTER2) | 0.3474 | 0.1739 | 0.3781 | 0.1069 |
+| Hybrid (SPECTER2) | 0.4526 | 0.2222 | 0.5012 | 0.1538 |
 
-At this stage, **TF-IDF is the strongest baseline** on the validation set, **hybrid retrieval improves over dense-only retrieval**, and **dense retrieval remains the weakest of the three approaches** on this small manually labeled benchmark.
+On the current 19-query validation split, **MiniLM remains the strongest dense encoder in this repo**, while **SPECTER2 is now fully supported as an ablation-ready scientific-domain alternative** with separate artifacts and metadata. Hybrid reranking still outperforms dense-only retrieval for both encoders.
 
 ### Reporting guidance for Part 2
 
@@ -180,7 +185,7 @@ For the report, document:
 
 | File | Description |
 | :--- | :--- |
-| `src/retrieval_extended.py` | Extends the Part 2 retriever to support vector-based searching and enforces 384-dim (MiniLM) alignment with the Part 1 index. |
+| `src/retrieval_extended.py` | Extends the Part 2 retriever with vector-based search and model-specific dense artifact loading (SPECTER2 by default). |
 | `src/feedback_logic.py` | Implements the core Rocchio algorithm: $Q_{new} = \alpha Q_{old} + \beta \mu(D_{pos}) - \gamma \mu(D_{neg})$. |
 | `src/qa_engine.py` | Orchestrates the RAG pipeline, including prompt engineering for scientific grounding and citation parsing. |
 | `run_part3.py` | The main orchestrator for the interactive loop, feedback processing, and grounded QA evaluation. |

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -24,7 +24,7 @@ preprocessing:
   chunk_overlap_tokens: 32
 
 embeddings:
-  dense_model: "sentence-transformers/all-MiniLM-L6-v2" # pretrained sentence-transformer verified to load in this environment
+  dense_model: "allenai/specter2_base" # scientific-domain dense encoder; MiniLM artifacts remain available for ablations
   dense_batch_size: 64
   dense_max_length: 512
   tfidf_max_features: 50000

--- a/data/dense_embeddings_specter2_meta.json
+++ b/data/dense_embeddings_specter2_meta.json
@@ -1,0 +1,12 @@
+{
+  "model_name": "allenai/specter2_base",
+  "simulated": false,
+  "embedding_dim": 768,
+  "n_documents": 20000,
+  "source_text": "title [SEP] abstract",
+  "created_at_utc": "2026-04-19T20:01:34.214736+00:00",
+  "artifact_file": "dense_embeddings_specter2.npy",
+  "encoder_backend": "specter2_adapters",
+  "document_adapter": "allenai/specter2",
+  "query_adapter": "allenai/specter2_adhoc_query"
+}

--- a/run_part2.py
+++ b/run_part2.py
@@ -26,6 +26,7 @@ def main():
     parser.add_argument("--top-k", type=int, default=10)
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--dense-candidates", type=int, default=100)
+    parser.add_argument("--dense-model", default=None)
     args = parser.parse_args()
 
     if args.bootstrap_queries:
@@ -33,19 +34,22 @@ def main():
     if args.split_queries:
         run_step("Split labeled queries into train/val/test", "src.split_queries")
     if args.evaluate:
+        eval_args = [
+            "--queries",
+            args.queries,
+            "--top-k",
+            str(args.top_k),
+            "--alpha",
+            str(args.alpha),
+            "--dense-candidates",
+            str(args.dense_candidates),
+        ]
+        if args.dense_model:
+            eval_args.extend(["--dense-model", args.dense_model])
         run_step(
             "Evaluate TF-IDF, dense, and hybrid retrieval",
             "src.evaluate",
-            [
-                "--queries",
-                args.queries,
-                "--top-k",
-                str(args.top_k),
-                "--alpha",
-                str(args.alpha),
-                "--dense-candidates",
-                str(args.dense_candidates),
-            ],
+            eval_args,
         )
 
     if not any([args.bootstrap_queries, args.split_queries, args.evaluate]):

--- a/src/dense_encoder.py
+++ b/src/dense_encoder.py
@@ -151,6 +151,9 @@ class DenseEncoder:
             set_active=True,
             local_files_only=self.local_files_only,
         )
+        if self.device:
+            # adapters are loaded after the base model is moved, so keep all weights on the same device.
+            self.model.to(self.device)
         self._loaded_adapters.add(adapter_name)
 
     def _encode_with_adapter(
@@ -163,10 +166,18 @@ class DenseEncoder:
         self._ensure_adapter(adapter_name)
 
         batches = []
-        for start in range(0, len(texts), batch_size):
+        batch_starts = range(0, len(texts), batch_size)
+        if show_progress_bar:
+            try:
+                from tqdm.auto import tqdm
+                batch_starts = tqdm(batch_starts, total=(len(texts) + batch_size - 1) // batch_size)
+            except ImportError:
+                pass
+
+        for start in batch_starts:
             text_batch = texts[start:start + batch_size]
             if start == 0:
-                logger.info("Encoding first batch with HF mean pooling backend.")
+                logger.info("Encoding first batch with adapter-backed transformer backend.")
             inputs = self.tokenizer(
                 text_batch,
                 padding=True,

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -111,10 +111,11 @@ def main():
     parser.add_argument("--top-k", type=int, default=10)
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--dense-candidates", type=int, default=100)
+    parser.add_argument("--dense-model", default=None)
     args = parser.parse_args()
 
     query_rows = load_jsonl(Path(args.queries))
-    retriever = PaperRetriever(config_path=args.config)
+    retriever = PaperRetriever(config_path=args.config, dense_model_name=args.dense_model)
 
     print(f"Evaluating {len(query_rows)} labeled queries from {args.queries}\n")
     for mode in ["tfidf", "dense", "hybrid"]:

--- a/src/feature_representation.py
+++ b/src/feature_representation.py
@@ -1,4 +1,5 @@
 import argparse
+from datetime import datetime, timezone
 import json
 import logging
 import pickle
@@ -9,6 +10,11 @@ import numpy as np
 import yaml
 
 from src.dense_encoder import DenseEncoder
+from src.part2_utils import (
+    dense_embedding_filename,
+    dense_embedding_metadata_filename,
+    dense_faiss_index_filename,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -89,6 +95,13 @@ def generate_simulated_embeddings(
     embeddings = normalize(embeddings, norm="l2")
     logger.info(f"Simulated embeddings shape: {embeddings.shape}")
     return embeddings.astype(np.float32)
+
+
+def build_dense_input_texts(papers: List[dict], model_name: str) -> List[str]:
+    if model_name == "allenai/specter2_base":
+        # AllenAI's documented SPECTER2 retrieval recipe separates title and abstract with BERT's [SEP] token.
+        return [f"{p['title']} [SEP] {p['abstract']}" for p in papers]
+    return [f"{p['title']}. {p['abstract']}" for p in papers]
 
 def feature_comparison_table(
     tfidf_vectorizer,
@@ -359,7 +372,7 @@ def main():
             papers.append(json.loads(line))
 
     cleaned_texts = [p["cleaned_text"] for p in papers]
-    raw_texts = [f"{p['title']}. {p['abstract']}" for p in papers]
+    raw_texts = build_dense_input_texts(papers, emb_cfg["dense_model"])
     categories = [p["categories"] for p in papers]
 
     vectorizer, tfidf_matrix = build_tfidf_features(
@@ -388,15 +401,21 @@ def main():
                 max_length=emb_cfg["dense_max_length"],
             )
 
-        np.save(str(data_dir / "dense_embeddings.npy"), dense_embeddings)
-        logger.info("Dense embeddings saved.")
+        embeddings_path = data_dir / dense_embedding_filename(emb_cfg["dense_model"])
+        metadata_path = data_dir / dense_embedding_metadata_filename(emb_cfg["dense_model"])
+        faiss_path = data_dir / dense_faiss_index_filename(emb_cfg["dense_model"])
+
+        np.save(str(embeddings_path), dense_embeddings)
+        logger.info("Dense embeddings saved to %s.", embeddings_path)
 
         dense_meta = {
             "model_name": emb_cfg["dense_model"],
             "simulated": simulated_mode,
             "embedding_dim": int(dense_embeddings.shape[1]),
             "n_documents": int(dense_embeddings.shape[0]),
-            "source_text": "title + abstract",
+            "source_text": "title [SEP] abstract" if emb_cfg["dense_model"] == "allenai/specter2_base" else "title + abstract",
+            "created_at_utc": datetime.now(timezone.utc).isoformat(),
+            "artifact_file": embeddings_path.name,
             "encoder_backend": (
                 "specter2_adapters"
                 if emb_cfg["dense_model"] == "allenai/specter2_base" and not simulated_mode
@@ -407,11 +426,11 @@ def main():
             "document_adapter": "allenai/specter2" if emb_cfg["dense_model"] == "allenai/specter2_base" and not simulated_mode else None,
             "query_adapter": "allenai/specter2_adhoc_query" if emb_cfg["dense_model"] == "allenai/specter2_base" and not simulated_mode else None,
         }
-        with open(data_dir / "dense_embeddings_meta.json", "w") as f:
+        with open(metadata_path, "w") as f:
             json.dump(dense_meta, f, indent=2)
-        logger.info("Dense embedding metadata saved.")
+        logger.info("Dense embedding metadata saved to %s.", metadata_path)
 
-        build_faiss_index(dense_embeddings, str(data_dir / "faiss_index.bin"))
+        build_faiss_index(dense_embeddings, str(faiss_path))
 
         table = feature_comparison_table(
             vectorizer, tfidf_matrix, dense_embeddings, emb_cfg["dense_model"]

--- a/src/part2_utils.py
+++ b/src/part2_utils.py
@@ -8,6 +8,10 @@ import numpy as np
 import yaml
 from scipy import sparse
 
+MODEL_ARTIFACT_SUFFIXES = {
+    "allenai/specter2_base": "specter2",
+}
+
 
 @dataclass
 class CorpusRecord:
@@ -32,6 +36,33 @@ def build_paper_lookup(papers: Sequence[dict]) -> Dict[str, dict]:
     return {paper["paper_id"]: paper for paper in papers}
 
 
+def dense_artifact_suffix(model_name: str | None) -> str | None:
+    if not model_name:
+        return None
+    return MODEL_ARTIFACT_SUFFIXES.get(model_name)
+
+
+def dense_embedding_filename(model_name: str | None = None) -> str:
+    suffix = dense_artifact_suffix(model_name)
+    if suffix:
+        return f"dense_embeddings_{suffix}.npy"
+    return "dense_embeddings.npy"
+
+
+def dense_embedding_metadata_filename(model_name: str | None = None) -> str:
+    suffix = dense_artifact_suffix(model_name)
+    if suffix:
+        return f"dense_embeddings_{suffix}_meta.json"
+    return "dense_embeddings_meta.json"
+
+
+def dense_faiss_index_filename(model_name: str | None = None) -> str:
+    suffix = dense_artifact_suffix(model_name)
+    if suffix:
+        return f"faiss_index_{suffix}.bin"
+    return "faiss_index.bin"
+
+
 def load_tfidf_artifacts(data_dir: Path):
     with open(data_dir / "tfidf_vectorizer.pkl", "rb") as f:
         vectorizer = pickle.load(f)
@@ -39,16 +70,27 @@ def load_tfidf_artifacts(data_dir: Path):
     return vectorizer, matrix
 
 
-def load_dense_embeddings(data_dir: Path) -> np.ndarray:
-    return np.load(data_dir / "dense_embeddings.npy")
+def load_dense_embeddings(data_dir: Path, model_name: str | None = None) -> np.ndarray:
+    return np.load(data_dir / dense_embedding_filename(model_name))
 
 
-def load_dense_embedding_metadata(data_dir: Path) -> dict | None:
-    meta_path = data_dir / "dense_embeddings_meta.json"
+def load_dense_embedding_metadata(data_dir: Path, model_name: str | None = None) -> dict | None:
+    meta_path = data_dir / dense_embedding_metadata_filename(model_name)
     if not meta_path.exists():
         return None
     with open(meta_path) as f:
         return json.load(f)
+
+
+def l2_normalize(values: np.ndarray) -> np.ndarray:
+    array = np.asarray(values, dtype=np.float32)
+    if array.ndim == 1:
+        norm = max(float(np.linalg.norm(array)), 1e-12)
+        return array / norm
+
+    norms = np.linalg.norm(array, axis=1, keepdims=True)
+    norms = np.clip(norms, 1e-12, None)
+    return array / norms
 
 
 def normalize_scores(scores: np.ndarray) -> np.ndarray:

--- a/src/retrieval.py
+++ b/src/retrieval.py
@@ -7,6 +7,8 @@ import numpy as np
 from src.dense_encoder import DenseEncoder
 from src.part2_utils import (
     build_paper_lookup,
+    dense_embedding_filename,
+    dense_embedding_metadata_filename,
     load_config,
     load_dense_embeddings,
     load_dense_embedding_metadata,
@@ -17,7 +19,11 @@ from src.part2_utils import (
 
 
 class PaperRetriever:
-    def __init__(self, config_path: str = "configs/config.yaml"):
+    def __init__(
+        self,
+        config_path: str = "configs/config.yaml",
+        dense_model_name: Optional[str] = None,
+    ):
         cfg = load_config(config_path)
         data_dir = Path(cfg["data_collection"]["output_path"]).parent
         corpus_path = data_dir / "arxiv_corpus_cleaned.jsonl"
@@ -28,9 +34,11 @@ class PaperRetriever:
         self.paper_lookup = build_paper_lookup(self.papers)
         self.paper_ids = [paper["paper_id"] for paper in self.papers]
         self.vectorizer, self.tfidf_matrix = load_tfidf_artifacts(data_dir)
-        self.dense_embeddings = load_dense_embeddings(data_dir)
-        self.dense_metadata = load_dense_embedding_metadata(data_dir)
-        self.dense_model_name = cfg["embeddings"]["dense_model"]
+        self.dense_model_name = dense_model_name or cfg["embeddings"]["dense_model"]
+        self.dense_embeddings_path = data_dir / dense_embedding_filename(self.dense_model_name)
+        self.dense_metadata_path = data_dir / dense_embedding_metadata_filename(self.dense_model_name)
+        self.dense_embeddings = load_dense_embeddings(data_dir, self.dense_model_name)
+        self.dense_metadata = load_dense_embedding_metadata(data_dir, self.dense_model_name)
         self._dense_encoder = None
 
     def _load_dense_encoder(self):
@@ -49,8 +57,8 @@ class PaperRetriever:
     def _validate_dense_setup(self):
         if self.dense_metadata is None:
             raise RuntimeError(
-                "Missing data/dense_embeddings_meta.json. "
-                "Regenerate dense embeddings with `python3 run_part1.py` so retrieval can verify compatibility."
+                f"Missing {self.dense_metadata_path}. Regenerate dense embeddings with "
+                "`python3 run_part1.py` so retrieval can verify compatibility."
             )
         if self.dense_metadata.get("simulated"):
             raise RuntimeError(
@@ -132,9 +140,14 @@ def main():
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--dense-candidates", type=int, default=100)
     parser.add_argument("--config", default="configs/config.yaml")
+    parser.add_argument(
+        "--dense-model",
+        default=None,
+        help="Override the dense model/artifact used for query encoding and retrieval.",
+    )
     args = parser.parse_args()
 
-    retriever = PaperRetriever(config_path=args.config)
+    retriever = PaperRetriever(config_path=args.config, dense_model_name=args.dense_model)
     if args.mode == "tfidf":
         results = retriever.retrieve_tfidf(args.query, k=args.k)
     elif args.mode == "dense":

--- a/src/retrieval_extended.py
+++ b/src/retrieval_extended.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+
+from src.dense_encoder import DenseEncoder
+from src.part2_utils import (
+    build_paper_lookup,
+    dense_embedding_filename,
+    dense_embedding_metadata_filename,
+    l2_normalize,
+    load_config,
+    load_dense_embedding_metadata,
+    load_dense_embeddings,
+    load_papers,
+)
+
+
+class PaperRetrieverExtended:
+    def __init__(
+        self,
+        config_path: str = "configs/config.yaml",
+        dense_model_name: Optional[str] = None,
+    ):
+        cfg = load_config(config_path)
+        data_dir = Path(cfg["data_collection"]["output_path"]).parent
+        corpus_path = data_dir / "arxiv_corpus_cleaned.jsonl"
+
+        self.cfg = cfg
+        self.data_dir = data_dir
+        self.papers = load_papers(str(corpus_path))
+        self.paper_lookup = build_paper_lookup(self.papers)
+        self.paper_ids = [paper["paper_id"] for paper in self.papers]
+        self.paper_id_to_index = {paper_id: idx for idx, paper_id in enumerate(self.paper_ids)}
+
+        # Stage 3 defaults to the scientific-domain SPECTER2 encoder.
+        self.dense_model_name = dense_model_name or "allenai/specter2_base"
+        self.dense_embeddings_path = data_dir / dense_embedding_filename(self.dense_model_name)
+        self.dense_metadata_path = data_dir / dense_embedding_metadata_filename(self.dense_model_name)
+        self.dense_embeddings = load_dense_embeddings(data_dir, self.dense_model_name)
+        self.dense_metadata = load_dense_embedding_metadata(data_dir, self.dense_model_name)
+        self._dense_encoder = None
+
+    def _load_dense_encoder(self):
+        self._validate_dense_setup()
+        if self._dense_encoder is not None:
+            return self._dense_encoder
+        self._dense_encoder = DenseEncoder(
+            model_name=self.dense_model_name,
+            max_length=self.cfg["embeddings"]["dense_max_length"],
+            document_adapter=self.dense_metadata.get("document_adapter") if self.dense_metadata else None,
+            query_adapter=self.dense_metadata.get("query_adapter") if self.dense_metadata else None,
+        )
+        self._dense_encoder.load()
+        return self._dense_encoder
+
+    def _validate_dense_setup(self):
+        if self.dense_metadata is None:
+            raise RuntimeError(
+                f"Missing {self.dense_metadata_path}. Regenerate dense embeddings for "
+                f"`{self.dense_model_name}` before running Part 3."
+            )
+        stored_model = self.dense_metadata.get("model_name")
+        if stored_model != self.dense_model_name:
+            raise RuntimeError(
+                f"Dense embedding model mismatch: metadata uses `{stored_model}`, "
+                f"but Stage 3 expects `{self.dense_model_name}`."
+            )
+        stored_dim = self.dense_metadata.get("embedding_dim")
+        if stored_dim is not None and int(stored_dim) != int(self.dense_embeddings.shape[1]):
+            raise RuntimeError(
+                f"Dense embedding metadata mismatch: metadata dim={stored_dim}, "
+                f"array dim={self.dense_embeddings.shape[1]}."
+            )
+
+    def _format_results(self, indices: np.ndarray, scores: np.ndarray) -> List[dict]:
+        results = []
+        for idx, score in zip(indices.tolist(), scores.tolist()):
+            paper = self.papers[idx]
+            results.append(
+                {
+                    "paper_id": paper["paper_id"],
+                    "arxiv_id": paper["arxiv_id"],
+                    "title": paper["title"],
+                    "abstract": paper["abstract"],
+                    "categories": paper["categories"],
+                    "score": float(score),
+                }
+            )
+        return results
+
+    def encode_query(self, query: str) -> np.ndarray:
+        encoder = self._load_dense_encoder()
+        return encoder.encode_queries([query])[0]
+
+    def encode_documents(self, texts: List[str]) -> np.ndarray:
+        encoder = self._load_dense_encoder()
+        return encoder.encode_documents(texts)
+
+    def get_embedding(self, paper_id: str) -> np.ndarray:
+        return self.dense_embeddings[self.paper_id_to_index[paper_id]]
+
+    def retrieve(self, query: str, k: int = 10) -> List[dict]:
+        return self.retrieve_by_vector(self.encode_query(query), k=k)
+
+    def retrieve_by_vector(self, query_vector: np.ndarray, k: int = 10) -> List[dict]:
+        query_vector = l2_normalize(query_vector)
+        scores = self.dense_embeddings @ query_vector
+        top_idx = np.argsort(scores)[::-1][:k]
+        return self._format_results(top_idx, scores[top_idx])


### PR DESCRIPTION
Closes #7

Implements SPECTER2 support across dense encoding, artifact naming, retrieval and evaluation entrypoints, and README reporting.

Notes:
- Keeps MiniLM artifacts for backward compatibility and ablation comparison.
- The large generated SPECTER2 embedding and FAISS files were regenerated locally and remain gitignored, while metadata is tracked.