### PR TITLE
[#6] Implement LLM-based reflective refinement (Method B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,23 +176,57 @@ For the report, document:
 ## Stage 3 — Interactive Feedback & Retrieval-Augmented Generation (RAG)
 ### Stage 3 Workflow
 
-1.  **Initial Retrieval**: Performs dense retrieval using an L2-normalized query vector.
-2.  **User/Pseudo Feedback**: Collects relevance labels. Supports **Pseudo-Relevance Feedback (PRF)**, which automatically assumes the Top-1 result is relevant to enable testing without manual labels.
-3.  **Query Refinement**: Updates the query vector using the **Rocchio Algorithm**, shifting the search embedding toward the relevant document cluster and away from non-relevant ones.
-4.  **Grounded Generation**: Feeds the refined Top-K abstracts into a Large Language Model (**UM GPT-oss-120B**) to produce a research summary with precise inline citations.
+1. **Initial Retrieval**: Performs dense retrieval using an L2-normalized query vector from the configured dense encoder.
+2. **User/Pseudo Feedback**: Collects explicit relevance labels when available. Supports **Pseudo-Relevance Feedback (PRF)**, which automatically treats the top-1 result as relevant for fast testing.
+3. **Query Refinement**: Supports three refinement modes:
+   - `rocchio`: standard vector-space relevance feedback.
+   - `llm`: asks a UM-hosted LLM to rewrite the query and return optional facet weights from feedback text.
+   - `combined`: applies Rocchio first, then lets the LLM rewrite the updated search intent before re-encoding.
+4. **Grounded Generation**: Feeds the final Top-K abstracts into a UM-hosted chat model to produce a grounded answer with inline citations.
 
 ### Source Files Added for Stage 3
 
 | File | Description |
 | :--- | :--- |
 | `src/retrieval_extended.py` | Extends the Part 2 retriever with vector-based search and model-specific dense artifact loading (SPECTER2 by default). |
-| `src/feedback_logic.py` | Implements the core Rocchio algorithm: $Q_{new} = \alpha Q_{old} + \beta \mu(D_{pos}) - \gamma \mu(D_{neg})$. |
-| `src/qa_engine.py` | Orchestrates the RAG pipeline, including prompt engineering for scientific grounding and citation parsing. |
-| `run_part3.py` | The main orchestrator for the interactive loop, feedback processing, and grounded QA evaluation. |
+| `src/feedback_logic.py` | Implements Rocchio updates and approximate facet-weight scaling on dense query vectors. |
+| `src/llm_refinement.py` | Calls the UM-hosted OpenAI-compatible endpoint to rewrite queries and return facet weights from feedback text. |
+| `src/qa_engine.py` | Orchestrates grounded answer generation with inline citations over retrieved abstracts. |
+| `run_part3.py` | Main entrypoint for interactive retrieval, relevance feedback, optional PRF, and grounded QA. |
 
 ### Step-by-Step Usage
 
-Run the full interactive pipeline (e.g., 1 round of feedback):
+Run one round of Rocchio feedback with grounded answer generation:
 
 ```bash
-python run_part3.py --queries data/queries_val.jsonl --rounds 1
+python run_part3.py --queries data/queries_val.jsonl --rounds 1 --feedback-method rocchio
+```
+
+Run one round of LLM-based reflective refinement with pseudo-feedback and no QA call:
+
+```bash
+python run_part3.py --queries data/queries_val.jsonl --rounds 1 --feedback-method llm --use_pseudo --skip-rag
+```
+
+Run the combined method on the SPECTER2 artifacts:
+
+```bash
+python run_part3.py --queries data/queries_val.jsonl --rounds 1 --feedback-method combined --dense-model allenai/specter2_base
+```
+
+Useful flags:
+
+- `--feedback-method {rocchio,llm,combined}` selects the refinement strategy.
+- `--rounds {0,1,2}` controls how many refinement rounds to run.
+- `--use_pseudo` enables pseudo-relevance feedback when no explicit positives are available.
+- `--skip-rag` runs retrieval/refinement only and skips the final answer-generation call.
+- `--max-queries N` limits evaluation to the first `N` queries for quick smoke tests.
+- `--dense-model MODEL_NAME` switches between dense artifact sets, including `sentence-transformers/all-MiniLM-L6-v2` and `allenai/specter2_base`.
+
+For the UM-hosted LLM endpoints, set:
+
+```bash
+export UM_GPTOSS_BASE_URL=http://<host>:8000/v1
+export UM_GPTOSS_API_KEY=<api_key>
+export UM_GPTOSS_MODEL=<model_name>
+```

--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ python3 -m src.evaluate --queries data/queries_test.jsonl --top-k 5 --alpha 0.5 
 ### Notes on dense retrieval
 
 - Dense retrieval expects the stored paper embeddings and the query encoder to be consistent.
-- If `data/dense_embeddings_meta.json` is missing, dense and hybrid retrieval will be skipped with a warning.
+- Dense artifacts are now model-specific:
+  - `allenai/specter2_base` -> `data/dense_embeddings_specter2.npy`, `data/dense_embeddings_specter2_meta.json`
+  - `sentence-transformers/all-MiniLM-L6-v2` -> legacy `data/dense_embeddings.npy`, `data/dense_embeddings_meta.json`
+- Use `--dense-model` with `src.retrieval`, `src.evaluate`, or `run_part2.py` to switch between SPECTER2 and MiniLM for ablations.
 - To regenerate dense artifacts and metadata, rerun Part 1:
 
 ```bash
@@ -147,15 +150,17 @@ python3 run_part1.py
 
 ### Current validation results
 
-Using the current validation split (`data/queries_val.jsonl`) with `top-k=10`, the initial paper-level results are:
+Using the current validation split (`data/queries_val.jsonl`) with `top-k=10` and `dense-candidates=100`, the current paper-level results are:
 
 | Method | Precision@10 | Recall@10 | NDCG@10 | MAP |
 | ------ | ------------ | --------- | ------- | --- |
-| TF-IDF | 0.5500 | 1.0000 | 0.8554 | 0.7523 |
-| Dense | 0.0500 | 0.1250 | 0.0588 | 0.0139 |
-| Hybrid | 0.2000 | 0.4464 | 0.4248 | 0.3115 |
+| TF-IDF | 0.4421 | 0.1957 | 0.4452 | 0.1131 |
+| Dense (MiniLM) | 0.5105 | 0.2334 | 0.5275 | 0.1498 |
+| Hybrid (MiniLM) | 0.5263 | 0.2441 | 0.5515 | 0.1642 |
+| Dense (SPECTER2) | 0.3474 | 0.1739 | 0.3781 | 0.1069 |
+| Hybrid (SPECTER2) | 0.4526 | 0.2222 | 0.5012 | 0.1538 |
 
-At this stage, **TF-IDF is the strongest baseline** on the validation set, **hybrid retrieval improves over dense-only retrieval**, and **dense retrieval remains the weakest of the three approaches** on this small manually labeled benchmark.
+On the current 19-query validation split, **MiniLM remains the strongest dense encoder in this repo**, while **SPECTER2 is now fully supported as an ablation-ready scientific-domain alternative** with separate artifacts and metadata. Hybrid reranking still outperforms dense-only retrieval for both encoders.
 
 ### Reporting guidance for Part 2
 
@@ -180,7 +185,7 @@ For the report, document:
 
 | File | Description |
 | :--- | :--- |
-| `src/retrieval_extended.py` | Extends the Part 2 retriever to support vector-based searching and enforces 384-dim (MiniLM) alignment with the Part 1 index. |
+| `src/retrieval_extended.py` | Extends the Part 2 retriever with vector-based search and model-specific dense artifact loading (SPECTER2 by default). |
 | `src/feedback_logic.py` | Implements the core Rocchio algorithm: $Q_{new} = \alpha Q_{old} + \beta \mu(D_{pos}) - \gamma \mu(D_{neg})$. |
 | `src/qa_engine.py` | Orchestrates the RAG pipeline, including prompt engineering for scientific grounding and citation parsing. |
 | `run_part3.py` | The main orchestrator for the interactive loop, feedback processing, and grounded QA evaluation. |

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -24,7 +24,7 @@ preprocessing:
   chunk_overlap_tokens: 32
 
 embeddings:
-  dense_model: "sentence-transformers/all-MiniLM-L6-v2" # pretrained sentence-transformer verified to load in this environment
+  dense_model: "allenai/specter2_base" # scientific-domain dense encoder; MiniLM artifacts remain available for ablations
   dense_batch_size: 64
   dense_max_length: 512
   tfidf_max_features: 50000

--- a/data/dense_embeddings_specter2_meta.json
+++ b/data/dense_embeddings_specter2_meta.json
@@ -1,0 +1,12 @@
+{
+  "model_name": "allenai/specter2_base",
+  "simulated": false,
+  "embedding_dim": 768,
+  "n_documents": 20000,
+  "source_text": "title [SEP] abstract",
+  "created_at_utc": "2026-04-19T20:01:34.214736+00:00",
+  "artifact_file": "dense_embeddings_specter2.npy",
+  "encoder_backend": "specter2_adapters",
+  "document_adapter": "allenai/specter2",
+  "query_adapter": "allenai/specter2_adhoc_query"
+}

--- a/run_part2.py
+++ b/run_part2.py
@@ -26,6 +26,7 @@ def main():
     parser.add_argument("--top-k", type=int, default=10)
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--dense-candidates", type=int, default=100)
+    parser.add_argument("--dense-model", default=None)
     args = parser.parse_args()
 
     if args.bootstrap_queries:
@@ -33,19 +34,22 @@ def main():
     if args.split_queries:
         run_step("Split labeled queries into train/val/test", "src.split_queries")
     if args.evaluate:
+        eval_args = [
+            "--queries",
+            args.queries,
+            "--top-k",
+            str(args.top_k),
+            "--alpha",
+            str(args.alpha),
+            "--dense-candidates",
+            str(args.dense_candidates),
+        ]
+        if args.dense_model:
+            eval_args.extend(["--dense-model", args.dense_model])
         run_step(
             "Evaluate TF-IDF, dense, and hybrid retrieval",
             "src.evaluate",
-            [
-                "--queries",
-                args.queries,
-                "--top-k",
-                str(args.top_k),
-                "--alpha",
-                str(args.alpha),
-                "--dense-candidates",
-                str(args.dense_candidates),
-            ],
+            eval_args,
         )
 
     if not any([args.bootstrap_queries, args.split_queries, args.evaluate]):

--- a/run_part3.py
+++ b/run_part3.py
@@ -1,79 +1,180 @@
 import argparse
 from pathlib import Path
-import numpy as np
-from src.retrieval_extended import PaperRetrieverExtended
+
+from src.feedback_logic import apply_facet_weights, apply_rocchio
+from src.llm_refinement import LLMRefinement
 from src.part2_utils import load_jsonl
-from src.feedback_logic import apply_rocchio
 from src.qa_engine import QAGenerator
+from src.retrieval_extended import PaperRetrieverExtended
+
 
 def normalize_id(paper_id: str) -> str:
-    """
-    Standardize ArXiv IDs by removing 'arxiv:' prefix and version suffixes like 'v1'.
-    """
     pid = str(paper_id).lower().strip()
     if pid.startswith("arxiv:"):
         pid = pid.replace("arxiv:", "")
-    if 'v' in pid:
-        pid = pid.split('v')[0]
+    if "v" in pid:
+        pid = pid.split("v")[0]
     return pid
+
+
+def build_feedback(
+    row: dict,
+    results: list[dict],
+    hits: list[dict],
+    use_pseudo: bool,
+) -> tuple[list[dict], str, bool]:
+    if hits:
+        explicit_feedback = row.get("user_feedback_text") or row.get("feedback_text")
+        if explicit_feedback:
+            return hits, str(explicit_feedback), False
+
+        hit_titles = "; ".join(result["title"] for result in hits[:3])
+        feedback = (
+            "The user marked these retrieved papers as relevant. "
+            f"Retrieve more work like: {hit_titles}."
+        )
+        return hits, feedback, False
+
+    if use_pseudo and results:
+        return [results[0]], "this is relevant, find more like it", True
+
+    return [], "", False
+
+
+def apply_feedback_method(
+    feedback_method: str,
+    retriever: PaperRetrieverExtended,
+    llm_refiner: LLMRefinement | None,
+    original_query: str,
+    current_query: str,
+    current_vector,
+    results: list[dict],
+    feedback_results: list[dict],
+    feedback_text: str,
+):
+    positive_vectors = [retriever.get_embedding(result["paper_id"]) for result in feedback_results]
+
+    if feedback_method == "rocchio":
+        return current_query, apply_rocchio(current_vector, positive_vectors), None
+
+    if llm_refiner is None:
+        raise RuntimeError("LLM-based feedback requires an initialized LLMRefinement instance.")
+
+    if feedback_method == "combined":
+        rocchio_vector = apply_rocchio(current_vector, positive_vectors)
+        llm_seed_results = retriever.retrieve_by_vector(rocchio_vector, k=len(results))
+    else:
+        llm_seed_results = results
+
+    refinement = llm_refiner.refine_query(
+        original_query=original_query,
+        current_query=current_query,
+        retrieved_titles=[result["title"] for result in llm_seed_results],
+        user_feedback_text=feedback_text,
+    )
+    refined_vector = retriever.encode_query(refinement.rewritten_query)
+    refined_vector = apply_facet_weights(refined_vector, refinement.facet_weights)
+    return refinement.rewritten_query, refined_vector, refinement
+
 
 def main():
     parser = argparse.ArgumentParser(description="Part 3: Relevance Feedback & RAG")
     parser.add_argument("--queries", default="data/queries_val.jsonl")
-    parser.add_argument("--rounds", type=int, default=1, help="Number of feedback iterations")
+    parser.add_argument("--rounds", type=int, choices=[0, 1, 2], default=1)
     parser.add_argument("--top_k", type=int, default=5, help="Number of documents to retrieve")
-    parser.add_argument("--use_pseudo", action="store_true", help="Enable PRF if no ground truth is found")
+    parser.add_argument("--use_pseudo", action="store_true", help="Enable PRF if no ground truth hit is found")
+    parser.add_argument(
+        "--feedback-method",
+        choices=["rocchio", "llm", "combined"],
+        default="rocchio",
+    )
+    parser.add_argument("--dense-model", default=None)
+    parser.add_argument("--skip-rag", action="store_true")
+    parser.add_argument("--max-queries", type=int, default=None)
     args = parser.parse_args()
 
-    # Initialize Retrieval and QA Engine
-    # Reminder: Must be on UM VPN for the GPT-oss-120B server
-    retriever = PaperRetrieverExtended()
-    qa_gen = QAGenerator()
-    query_rows = load_jsonl(Path(args.queries))
+    retriever = PaperRetrieverExtended(dense_model_name=args.dense_model)
+    llm_refiner = LLMRefinement() if args.feedback_method in {"llm", "combined"} else None
+    qa_gen = None if args.skip_rag else QAGenerator()
 
-    print(f"Executing Part 3 evaluation on {len(query_rows)} queries...")
+    query_rows = load_jsonl(Path(args.queries))
+    if args.max_queries is not None:
+        query_rows = query_rows[:args.max_queries]
+
+    print(
+        f"Executing Part 3 evaluation on {len(query_rows)} queries "
+        f"(feedback_method={args.feedback_method}, rounds={args.rounds})..."
+    )
 
     for row in query_rows:
         query_text = row["query_text"]
         relevant_ids = {normalize_id(idx) for idx in row.get("relevant_arxiv_ids", [])}
-        
-        print(f"\n{'='*80}")
-        print(f"QUERY: {query_text}")
-        print(f"{'='*80}")
-        
-        # 1. Generate initial query vector
-        current_vec = retriever.encode_query(query_text)
-        
+        current_query = query_text
+        current_vector = retriever.encode_query(current_query)
         final_results = []
-        for r in range(args.rounds + 1):
-            # 2. Retrieve papers
-            results = retriever.retrieve_by_vector(current_vec, k=args.top_k)
+
+        print(f"\n{'=' * 80}")
+        print(f"QUERY: {query_text}")
+        print(f"{'=' * 80}")
+
+        for round_idx in range(args.rounds + 1):
+            results = retriever.retrieve_by_vector(current_vector, k=args.top_k)
             final_results = results
-            
-            # Calculate Precision based on normalized IDs
-            hits = [res for res in results if normalize_id(res['arxiv_id']) in relevant_ids]
-            precision = len(hits) / args.top_k
-            print(f"Round {r} | Precision@{args.top_k}: {precision:.2f}")
+            hits = [result for result in results if normalize_id(result["arxiv_id"]) in relevant_ids]
+            precision = len(hits) / max(args.top_k, 1)
+            print(f"Round {round_idx} | Precision@{args.top_k}: {precision:.2f} | Hits: {len(hits)}")
 
-            # 3. Apply Rocchio Feedback Logic
-            if r < args.rounds:
-                if hits:
-                    # Standard Rocchio using ground truth hits
-                    pos_vecs = [retriever.dense_embeddings[retriever.paper_ids.index(h['paper_id'])] for h in hits]
-                    current_vec = apply_rocchio(current_vec, pos_vecs)
-                    print(f"  --> Vector updated using {len(hits)} relevant papers.")
-                elif args.use_pseudo:
-                    # Pseudo-Relevance Feedback (PRF) for demonstration
-                    print(f"  --> Applying Pseudo-Feedback using the top-ranked document.")
-                    top_1_id = results[0]['paper_id']
-                    top_1_vec = retriever.dense_embeddings[retriever.paper_ids.index(top_1_id)]
-                    current_vec = apply_rocchio(current_vec, [top_1_vec])
+            if round_idx >= args.rounds:
+                continue
 
-        # 4. Generate grounded answer using retrieved context and UM Server
+            feedback_results, feedback_text, pseudo_used = build_feedback(
+                row=row,
+                results=results,
+                hits=hits,
+                use_pseudo=args.use_pseudo,
+            )
+            if not feedback_results:
+                print("  --> No positive feedback available; stopping refinement early.")
+                break
+
+            if pseudo_used:
+                print("  --> Applying pseudo-feedback using the top-ranked document.")
+
+            try:
+                current_query, current_vector, refinement = apply_feedback_method(
+                    feedback_method=args.feedback_method,
+                    retriever=retriever,
+                    llm_refiner=llm_refiner,
+                    original_query=query_text,
+                    current_query=current_query,
+                    current_vector=current_vector,
+                    results=results,
+                    feedback_results=feedback_results,
+                    feedback_text=feedback_text,
+                )
+            except Exception as exc:
+                print(f"  --> Feedback refinement failed: {exc}")
+                break
+
+            if refinement is not None:
+                print(f"  --> Rewritten query: {refinement.rewritten_query}")
+                print(f"  --> Facet weights: {refinement.facet_weights}")
+                if refinement.explanation:
+                    print(f"  --> LLM rationale: {refinement.explanation}")
+            else:
+                print(f"  --> Rocchio updated the query vector using {len(feedback_results)} positives.")
+
+        if qa_gen is None:
+            continue
+
         print("\n[RAG] Generating answer via UM GPT-oss-120B...")
         context = qa_gen.format_context(final_results)
-        answer = qa_gen.generate_answer(query_text, context)
-        print(f"\n[AI Answer]:\n{answer}\n")
+        try:
+            answer = qa_gen.generate_answer(current_query, context)
+            print(f"\n[AI Answer]:\n{answer}\n")
+        except Exception as exc:
+            print(f"\n[RAG] Skipped: {exc}\n")
+
 
 if __name__ == "__main__":
     main()

--- a/src/dense_encoder.py
+++ b/src/dense_encoder.py
@@ -2,11 +2,27 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+def _repo_cached(repo_id: str, required_file_groups: Sequence[Sequence[str]]) -> bool:
+    try:
+        from huggingface_hub import try_to_load_from_cache
+    except ImportError:
+        return False
+
+    for group in required_file_groups:
+        if not any(
+            isinstance(cached_path := try_to_load_from_cache(repo_id, filename), str)
+            and os.path.exists(cached_path)
+            for filename in group
+        ):
+            return False
+    return True
 
 
 def _normalize(embeddings: np.ndarray) -> np.ndarray:
@@ -61,23 +77,31 @@ class DenseEncoder:
 
             self._torch = torch
             os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+            model_local_only = self.local_files_only or _repo_cached(
+                self.model_name,
+                [
+                    ["config.json"],
+                    ["tokenizer_config.json"],
+                    ["model.safetensors", "pytorch_model.bin"],
+                ],
+            )
             logger.info(
                 "Loading SPECTER2 base tokenizer from %s (local_files_only=%s)",
                 self.model_name,
-                self.local_files_only,
+                model_local_only,
             )
             self.tokenizer = AutoTokenizer.from_pretrained(
                 self.model_name,
-                local_files_only=self.local_files_only,
+                local_files_only=model_local_only,
             )
             logger.info(
                 "Loading SPECTER2 base model from %s (local_files_only=%s)",
                 self.model_name,
-                self.local_files_only,
+                model_local_only,
             )
             self.model = AutoAdapterModel.from_pretrained(
                 self.model_name,
-                local_files_only=self.local_files_only,
+                local_files_only=model_local_only,
             )
             if self.device:
                 self.model.to(self.device)
@@ -93,23 +117,31 @@ class DenseEncoder:
 
             self._torch = torch
             os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+            model_local_only = self.local_files_only or _repo_cached(
+                self.model_name,
+                [
+                    ["config.json"],
+                    ["tokenizer_config.json"],
+                    ["model.safetensors", "pytorch_model.bin"],
+                ],
+            )
             logger.info(
                 "Loading HF tokenizer from %s (local_files_only=%s)",
                 self.model_name,
-                self.local_files_only,
+                model_local_only,
             )
             self.tokenizer = AutoTokenizer.from_pretrained(
                 self.model_name,
-                local_files_only=self.local_files_only,
+                local_files_only=model_local_only,
             )
             logger.info(
                 "Tokenizer loaded. Loading HF model from %s (local_files_only=%s)",
                 self.model_name,
-                self.local_files_only,
+                model_local_only,
             )
             self._transformers_model = AutoModel.from_pretrained(
                 self.model_name,
-                local_files_only=self.local_files_only,
+                local_files_only=model_local_only,
                 low_cpu_mem_usage=True,
             )
             logger.info("HF model loaded.")
@@ -139,17 +171,24 @@ class DenseEncoder:
         if adapter_name in self._loaded_adapters:
             self.model.set_active_adapters(adapter_name)
             return
+        adapter_local_only = self.local_files_only or _repo_cached(
+            adapter_name,
+            [
+                ["adapter_config.json"],
+                ["adapter_model.safetensors", "pytorch_adapter.bin"],
+            ],
+        )
         logger.info(
             "Loading adapter %s (local_files_only=%s)",
             adapter_name,
-            self.local_files_only,
+            adapter_local_only,
         )
         self.model.load_adapter(
             adapter_name,
             source="hf",
             load_as=adapter_name,
             set_active=True,
-            local_files_only=self.local_files_only,
+            local_files_only=adapter_local_only,
         )
         if self.device:
             # adapters are loaded after the base model is moved, so keep all weights on the same device.

--- a/src/dense_encoder.py
+++ b/src/dense_encoder.py
@@ -151,6 +151,9 @@ class DenseEncoder:
             set_active=True,
             local_files_only=self.local_files_only,
         )
+        if self.device:
+            # adapters are loaded after the base model is moved, so keep all weights on the same device.
+            self.model.to(self.device)
         self._loaded_adapters.add(adapter_name)
 
     def _encode_with_adapter(
@@ -163,10 +166,18 @@ class DenseEncoder:
         self._ensure_adapter(adapter_name)
 
         batches = []
-        for start in range(0, len(texts), batch_size):
+        batch_starts = range(0, len(texts), batch_size)
+        if show_progress_bar:
+            try:
+                from tqdm.auto import tqdm
+                batch_starts = tqdm(batch_starts, total=(len(texts) + batch_size - 1) // batch_size)
+            except ImportError:
+                pass
+
+        for start in batch_starts:
             text_batch = texts[start:start + batch_size]
             if start == 0:
-                logger.info("Encoding first batch with HF mean pooling backend.")
+                logger.info("Encoding first batch with adapter-backed transformer backend.")
             inputs = self.tokenizer(
                 text_batch,
                 padding=True,

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -111,10 +111,11 @@ def main():
     parser.add_argument("--top-k", type=int, default=10)
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--dense-candidates", type=int, default=100)
+    parser.add_argument("--dense-model", default=None)
     args = parser.parse_args()
 
     query_rows = load_jsonl(Path(args.queries))
-    retriever = PaperRetriever(config_path=args.config)
+    retriever = PaperRetriever(config_path=args.config, dense_model_name=args.dense_model)
 
     print(f"Evaluating {len(query_rows)} labeled queries from {args.queries}\n")
     for mode in ["tfidf", "dense", "hybrid"]:

--- a/src/feature_representation.py
+++ b/src/feature_representation.py
@@ -1,4 +1,5 @@
 import argparse
+from datetime import datetime, timezone
 import json
 import logging
 import pickle
@@ -9,6 +10,11 @@ import numpy as np
 import yaml
 
 from src.dense_encoder import DenseEncoder
+from src.part2_utils import (
+    dense_embedding_filename,
+    dense_embedding_metadata_filename,
+    dense_faiss_index_filename,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -89,6 +95,13 @@ def generate_simulated_embeddings(
     embeddings = normalize(embeddings, norm="l2")
     logger.info(f"Simulated embeddings shape: {embeddings.shape}")
     return embeddings.astype(np.float32)
+
+
+def build_dense_input_texts(papers: List[dict], model_name: str) -> List[str]:
+    if model_name == "allenai/specter2_base":
+        # AllenAI's documented SPECTER2 retrieval recipe separates title and abstract with BERT's [SEP] token.
+        return [f"{p['title']} [SEP] {p['abstract']}" for p in papers]
+    return [f"{p['title']}. {p['abstract']}" for p in papers]
 
 def feature_comparison_table(
     tfidf_vectorizer,
@@ -359,7 +372,7 @@ def main():
             papers.append(json.loads(line))
 
     cleaned_texts = [p["cleaned_text"] for p in papers]
-    raw_texts = [f"{p['title']}. {p['abstract']}" for p in papers]
+    raw_texts = build_dense_input_texts(papers, emb_cfg["dense_model"])
     categories = [p["categories"] for p in papers]
 
     vectorizer, tfidf_matrix = build_tfidf_features(
@@ -388,15 +401,21 @@ def main():
                 max_length=emb_cfg["dense_max_length"],
             )
 
-        np.save(str(data_dir / "dense_embeddings.npy"), dense_embeddings)
-        logger.info("Dense embeddings saved.")
+        embeddings_path = data_dir / dense_embedding_filename(emb_cfg["dense_model"])
+        metadata_path = data_dir / dense_embedding_metadata_filename(emb_cfg["dense_model"])
+        faiss_path = data_dir / dense_faiss_index_filename(emb_cfg["dense_model"])
+
+        np.save(str(embeddings_path), dense_embeddings)
+        logger.info("Dense embeddings saved to %s.", embeddings_path)
 
         dense_meta = {
             "model_name": emb_cfg["dense_model"],
             "simulated": simulated_mode,
             "embedding_dim": int(dense_embeddings.shape[1]),
             "n_documents": int(dense_embeddings.shape[0]),
-            "source_text": "title + abstract",
+            "source_text": "title [SEP] abstract" if emb_cfg["dense_model"] == "allenai/specter2_base" else "title + abstract",
+            "created_at_utc": datetime.now(timezone.utc).isoformat(),
+            "artifact_file": embeddings_path.name,
             "encoder_backend": (
                 "specter2_adapters"
                 if emb_cfg["dense_model"] == "allenai/specter2_base" and not simulated_mode
@@ -407,11 +426,11 @@ def main():
             "document_adapter": "allenai/specter2" if emb_cfg["dense_model"] == "allenai/specter2_base" and not simulated_mode else None,
             "query_adapter": "allenai/specter2_adhoc_query" if emb_cfg["dense_model"] == "allenai/specter2_base" and not simulated_mode else None,
         }
-        with open(data_dir / "dense_embeddings_meta.json", "w") as f:
+        with open(metadata_path, "w") as f:
             json.dump(dense_meta, f, indent=2)
-        logger.info("Dense embedding metadata saved.")
+        logger.info("Dense embedding metadata saved to %s.", metadata_path)
 
-        build_faiss_index(dense_embeddings, str(data_dir / "faiss_index.bin"))
+        build_faiss_index(dense_embeddings, str(faiss_path))
 
         table = feature_comparison_table(
             vectorizer, tfidf_matrix, dense_embeddings, emb_cfg["dense_model"]

--- a/src/feedback_logic.py
+++ b/src/feedback_logic.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from src.part2_utils import l2_normalize
+
+
+def apply_rocchio(
+    query_vector: np.ndarray,
+    positive_vectors: Sequence[np.ndarray],
+    negative_vectors: Sequence[np.ndarray] | None = None,
+    alpha: float = 1.0,
+    beta: float = 0.75,
+    gamma: float = 0.15,
+) -> np.ndarray:
+    updated = alpha * np.asarray(query_vector, dtype=np.float32)
+
+    if positive_vectors:
+        updated += beta * np.mean(np.asarray(positive_vectors, dtype=np.float32), axis=0)
+    if negative_vectors:
+        updated -= gamma * np.mean(np.asarray(negative_vectors, dtype=np.float32), axis=0)
+
+    return l2_normalize(updated)
+
+
+def apply_facet_weights(
+    query_vector: np.ndarray,
+    facet_weights: Sequence[float] | None,
+) -> np.ndarray:
+    query_vector = np.asarray(query_vector, dtype=np.float32)
+    if not facet_weights:
+        return l2_normalize(query_vector)
+
+    facet_weights = [float(weight) for weight in facet_weights]
+    scale = np.ones_like(query_vector, dtype=np.float32)
+    n_facets = max(len(facet_weights), 1)
+
+    # The encoder has no explicit facet basis, so we approximate a facet vector by
+    # scaling contiguous slices of the dense query representation.
+    for idx, weight in enumerate(facet_weights):
+        start = (query_vector.shape[0] * idx) // n_facets
+        end = (query_vector.shape[0] * (idx + 1)) // n_facets
+        scale[start:end] = weight
+
+    return l2_normalize(query_vector * scale)

--- a/src/llm_refinement.py
+++ b/src/llm_refinement.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from openai import OpenAI
+
+
+DEFAULT_BASE_URL = "http://promaxgb10-d473.eecs.umich.edu:8000/v1"
+DEFAULT_MODEL = "openai/gpt-oss-120b"
+DEFAULT_FACETS = [
+    "background_survey",
+    "concrete_system",
+    "method_algorithm",
+    "dataset_benchmark",
+    "evaluation_results",
+    "efficiency_scaling",
+]
+
+
+@dataclass
+class RefinementResult:
+    rewritten_query: str
+    facet_weights: List[float]
+    explanation: str
+    raw_response: str
+
+
+def _extract_json_object(text: str) -> dict:
+    text = text.strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or start >= end:
+        raise ValueError(f"LLM response did not contain JSON: {text[:200]}")
+    return json.loads(text[start:end + 1])
+
+
+class LLMRefinement:
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+        facets: Sequence[str] | None = None,
+    ):
+        self.base_url = base_url or os.environ.get("UM_GPTOSS_BASE_URL") or DEFAULT_BASE_URL
+        self.api_key = api_key or os.environ.get("UM_GPTOSS_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        self.model = model or os.environ.get("UM_GPTOSS_MODEL") or DEFAULT_MODEL
+        self.facets = list(facets or DEFAULT_FACETS)
+        self._client = OpenAI(base_url=self.base_url, api_key=self.api_key) if self.api_key else None
+
+    def refine_query(
+        self,
+        original_query: str,
+        current_query: str,
+        retrieved_titles: Sequence[str],
+        user_feedback_text: str,
+    ) -> RefinementResult:
+        if self._client is None:
+            raise RuntimeError(
+                "Missing UM_GPTOSS_API_KEY / OPENAI_API_KEY. "
+                "Set the API key before using LLM-based refinement."
+            )
+
+        titles_text = "\n".join(f"- {title}" for title in retrieved_titles[:8]) or "- No retrieved titles available"
+        facets_text = ", ".join(self.facets)
+        prompt = (
+            "You are refining a scientific-literature search query after relevance feedback.\n"
+            "Return valid JSON only with this schema:\n"
+            "{\n"
+            '  "rewritten_query": "short improved search query",\n'
+            f'  "facet_weights": [{", ".join(["1.0"] * len(self.facets))}],\n'
+            '  "explanation": "one short sentence"\n'
+            "}\n"
+            "Rules:\n"
+            "- Keep the rewritten query concise and targeted.\n"
+            "- Incorporate the user feedback directly.\n"
+            f"- facet_weights must contain exactly {len(self.facets)} floats in [0.5, 1.5].\n"
+            f"- Facet order: {facets_text}.\n"
+            "- Prefer terms useful for scientific-paper retrieval, not conversational prose.\n\n"
+            f"Original query: {original_query}\n"
+            f"Current query: {current_query}\n"
+            f"Retrieved titles:\n{titles_text}\n"
+            f"User feedback: {user_feedback_text}\n"
+        )
+
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=300,
+            temperature=0.0,
+        )
+        content = response.choices[0].message.content or ""
+        payload = _extract_json_object(content)
+
+        rewritten_query = str(payload.get("rewritten_query", current_query)).strip() or current_query
+        facet_weights = payload.get("facet_weights", [1.0] * len(self.facets))
+        if not isinstance(facet_weights, list) or len(facet_weights) != len(self.facets):
+            facet_weights = [1.0] * len(self.facets)
+        clipped_weights = [min(1.5, max(0.5, float(weight))) for weight in facet_weights]
+
+        return RefinementResult(
+            rewritten_query=rewritten_query,
+            facet_weights=clipped_weights,
+            explanation=str(payload.get("explanation", "")).strip(),
+            raw_response=content,
+        )

--- a/src/part2_utils.py
+++ b/src/part2_utils.py
@@ -8,6 +8,10 @@ import numpy as np
 import yaml
 from scipy import sparse
 
+MODEL_ARTIFACT_SUFFIXES = {
+    "allenai/specter2_base": "specter2",
+}
+
 
 @dataclass
 class CorpusRecord:
@@ -32,6 +36,33 @@ def build_paper_lookup(papers: Sequence[dict]) -> Dict[str, dict]:
     return {paper["paper_id"]: paper for paper in papers}
 
 
+def dense_artifact_suffix(model_name: str | None) -> str | None:
+    if not model_name:
+        return None
+    return MODEL_ARTIFACT_SUFFIXES.get(model_name)
+
+
+def dense_embedding_filename(model_name: str | None = None) -> str:
+    suffix = dense_artifact_suffix(model_name)
+    if suffix:
+        return f"dense_embeddings_{suffix}.npy"
+    return "dense_embeddings.npy"
+
+
+def dense_embedding_metadata_filename(model_name: str | None = None) -> str:
+    suffix = dense_artifact_suffix(model_name)
+    if suffix:
+        return f"dense_embeddings_{suffix}_meta.json"
+    return "dense_embeddings_meta.json"
+
+
+def dense_faiss_index_filename(model_name: str | None = None) -> str:
+    suffix = dense_artifact_suffix(model_name)
+    if suffix:
+        return f"faiss_index_{suffix}.bin"
+    return "faiss_index.bin"
+
+
 def load_tfidf_artifacts(data_dir: Path):
     with open(data_dir / "tfidf_vectorizer.pkl", "rb") as f:
         vectorizer = pickle.load(f)
@@ -39,16 +70,27 @@ def load_tfidf_artifacts(data_dir: Path):
     return vectorizer, matrix
 
 
-def load_dense_embeddings(data_dir: Path) -> np.ndarray:
-    return np.load(data_dir / "dense_embeddings.npy")
+def load_dense_embeddings(data_dir: Path, model_name: str | None = None) -> np.ndarray:
+    return np.load(data_dir / dense_embedding_filename(model_name))
 
 
-def load_dense_embedding_metadata(data_dir: Path) -> dict | None:
-    meta_path = data_dir / "dense_embeddings_meta.json"
+def load_dense_embedding_metadata(data_dir: Path, model_name: str | None = None) -> dict | None:
+    meta_path = data_dir / dense_embedding_metadata_filename(model_name)
     if not meta_path.exists():
         return None
     with open(meta_path) as f:
         return json.load(f)
+
+
+def l2_normalize(values: np.ndarray) -> np.ndarray:
+    array = np.asarray(values, dtype=np.float32)
+    if array.ndim == 1:
+        norm = max(float(np.linalg.norm(array)), 1e-12)
+        return array / norm
+
+    norms = np.linalg.norm(array, axis=1, keepdims=True)
+    norms = np.clip(norms, 1e-12, None)
+    return array / norms
 
 
 def normalize_scores(scores: np.ndarray) -> np.ndarray:

--- a/src/qa_engine.py
+++ b/src/qa_engine.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+
+from openai import OpenAI
+
+
+DEFAULT_BASE_URL = "http://promaxgb10-d473.eecs.umich.edu:8000/v1"
+DEFAULT_MODEL = "openai/gpt-oss-120b"
+
+
+class QAGenerator:
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+    ):
+        self.base_url = base_url or os.environ.get("UM_GPTOSS_BASE_URL") or DEFAULT_BASE_URL
+        self.api_key = api_key or os.environ.get("UM_GPTOSS_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        self.model = model or os.environ.get("UM_GPTOSS_MODEL") or DEFAULT_MODEL
+        self._client = OpenAI(base_url=self.base_url, api_key=self.api_key) if self.api_key else None
+
+    def format_context(self, results: list[dict]) -> str:
+        sections = []
+        for idx, paper in enumerate(results, start=1):
+            abstract = paper["abstract"].replace("\n", " ").strip()
+            sections.append(
+                f"[{idx}] {paper['title']}\n"
+                f"ArXiv ID: {paper['arxiv_id']}\n"
+                f"Abstract: {abstract}\n"
+            )
+        return "\n".join(sections)
+
+    def generate_answer(self, question: str, context: str) -> str:
+        if self._client is None:
+            raise RuntimeError(
+                "Missing UM_GPTOSS_API_KEY / OPENAI_API_KEY. "
+                "Set the API key before running grounded QA."
+            )
+
+        prompt = (
+            "Answer the user's research question using only the provided paper snippets.\n"
+            "When making a claim, cite the supporting snippet index like [1] or [2].\n"
+            "If the context is insufficient, say so plainly.\n\n"
+            f"Question: {question}\n\n"
+            f"Context:\n{context}\n"
+        )
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=600,
+            temperature=0.1,
+        )
+        return (response.choices[0].message.content or "").strip()

--- a/src/retrieval.py
+++ b/src/retrieval.py
@@ -7,6 +7,8 @@ import numpy as np
 from src.dense_encoder import DenseEncoder
 from src.part2_utils import (
     build_paper_lookup,
+    dense_embedding_filename,
+    dense_embedding_metadata_filename,
     load_config,
     load_dense_embeddings,
     load_dense_embedding_metadata,
@@ -17,7 +19,11 @@ from src.part2_utils import (
 
 
 class PaperRetriever:
-    def __init__(self, config_path: str = "configs/config.yaml"):
+    def __init__(
+        self,
+        config_path: str = "configs/config.yaml",
+        dense_model_name: Optional[str] = None,
+    ):
         cfg = load_config(config_path)
         data_dir = Path(cfg["data_collection"]["output_path"]).parent
         corpus_path = data_dir / "arxiv_corpus_cleaned.jsonl"
@@ -28,9 +34,11 @@ class PaperRetriever:
         self.paper_lookup = build_paper_lookup(self.papers)
         self.paper_ids = [paper["paper_id"] for paper in self.papers]
         self.vectorizer, self.tfidf_matrix = load_tfidf_artifacts(data_dir)
-        self.dense_embeddings = load_dense_embeddings(data_dir)
-        self.dense_metadata = load_dense_embedding_metadata(data_dir)
-        self.dense_model_name = cfg["embeddings"]["dense_model"]
+        self.dense_model_name = dense_model_name or cfg["embeddings"]["dense_model"]
+        self.dense_embeddings_path = data_dir / dense_embedding_filename(self.dense_model_name)
+        self.dense_metadata_path = data_dir / dense_embedding_metadata_filename(self.dense_model_name)
+        self.dense_embeddings = load_dense_embeddings(data_dir, self.dense_model_name)
+        self.dense_metadata = load_dense_embedding_metadata(data_dir, self.dense_model_name)
         self._dense_encoder = None
 
     def _load_dense_encoder(self):
@@ -49,8 +57,8 @@ class PaperRetriever:
     def _validate_dense_setup(self):
         if self.dense_metadata is None:
             raise RuntimeError(
-                "Missing data/dense_embeddings_meta.json. "
-                "Regenerate dense embeddings with `python3 run_part1.py` so retrieval can verify compatibility."
+                f"Missing {self.dense_metadata_path}. Regenerate dense embeddings with "
+                "`python3 run_part1.py` so retrieval can verify compatibility."
             )
         if self.dense_metadata.get("simulated"):
             raise RuntimeError(
@@ -132,9 +140,14 @@ def main():
     parser.add_argument("--alpha", type=float, default=0.5)
     parser.add_argument("--dense-candidates", type=int, default=100)
     parser.add_argument("--config", default="configs/config.yaml")
+    parser.add_argument(
+        "--dense-model",
+        default=None,
+        help="Override the dense model/artifact used for query encoding and retrieval.",
+    )
     args = parser.parse_args()
 
-    retriever = PaperRetriever(config_path=args.config)
+    retriever = PaperRetriever(config_path=args.config, dense_model_name=args.dense_model)
     if args.mode == "tfidf":
         results = retriever.retrieve_tfidf(args.query, k=args.k)
     elif args.mode == "dense":

--- a/src/retrieval_extended.py
+++ b/src/retrieval_extended.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+
+from src.dense_encoder import DenseEncoder
+from src.part2_utils import (
+    build_paper_lookup,
+    dense_embedding_filename,
+    dense_embedding_metadata_filename,
+    l2_normalize,
+    load_config,
+    load_dense_embedding_metadata,
+    load_dense_embeddings,
+    load_papers,
+)
+
+
+class PaperRetrieverExtended:
+    def __init__(
+        self,
+        config_path: str = "configs/config.yaml",
+        dense_model_name: Optional[str] = None,
+    ):
+        cfg = load_config(config_path)
+        data_dir = Path(cfg["data_collection"]["output_path"]).parent
+        corpus_path = data_dir / "arxiv_corpus_cleaned.jsonl"
+
+        self.cfg = cfg
+        self.data_dir = data_dir
+        self.papers = load_papers(str(corpus_path))
+        self.paper_lookup = build_paper_lookup(self.papers)
+        self.paper_ids = [paper["paper_id"] for paper in self.papers]
+        self.paper_id_to_index = {paper_id: idx for idx, paper_id in enumerate(self.paper_ids)}
+
+        # Stage 3 defaults to the scientific-domain SPECTER2 encoder.
+        self.dense_model_name = dense_model_name or "allenai/specter2_base"
+        self.dense_embeddings_path = data_dir / dense_embedding_filename(self.dense_model_name)
+        self.dense_metadata_path = data_dir / dense_embedding_metadata_filename(self.dense_model_name)
+        self.dense_embeddings = load_dense_embeddings(data_dir, self.dense_model_name)
+        self.dense_metadata = load_dense_embedding_metadata(data_dir, self.dense_model_name)
+        self._dense_encoder = None
+
+    def _load_dense_encoder(self):
+        self._validate_dense_setup()
+        if self._dense_encoder is not None:
+            return self._dense_encoder
+        self._dense_encoder = DenseEncoder(
+            model_name=self.dense_model_name,
+            max_length=self.cfg["embeddings"]["dense_max_length"],
+            document_adapter=self.dense_metadata.get("document_adapter") if self.dense_metadata else None,
+            query_adapter=self.dense_metadata.get("query_adapter") if self.dense_metadata else None,
+        )
+        self._dense_encoder.load()
+        return self._dense_encoder
+
+    def _validate_dense_setup(self):
+        if self.dense_metadata is None:
+            raise RuntimeError(
+                f"Missing {self.dense_metadata_path}. Regenerate dense embeddings for "
+                f"`{self.dense_model_name}` before running Part 3."
+            )
+        stored_model = self.dense_metadata.get("model_name")
+        if stored_model != self.dense_model_name:
+            raise RuntimeError(
+                f"Dense embedding model mismatch: metadata uses `{stored_model}`, "
+                f"but Stage 3 expects `{self.dense_model_name}`."
+            )
+        stored_dim = self.dense_metadata.get("embedding_dim")
+        if stored_dim is not None and int(stored_dim) != int(self.dense_embeddings.shape[1]):
+            raise RuntimeError(
+                f"Dense embedding metadata mismatch: metadata dim={stored_dim}, "
+                f"array dim={self.dense_embeddings.shape[1]}."
+            )
+
+    def _format_results(self, indices: np.ndarray, scores: np.ndarray) -> List[dict]:
+        results = []
+        for idx, score in zip(indices.tolist(), scores.tolist()):
+            paper = self.papers[idx]
+            results.append(
+                {
+                    "paper_id": paper["paper_id"],
+                    "arxiv_id": paper["arxiv_id"],
+                    "title": paper["title"],
+                    "abstract": paper["abstract"],
+                    "categories": paper["categories"],
+                    "score": float(score),
+                }
+            )
+        return results
+
+    def encode_query(self, query: str) -> np.ndarray:
+        encoder = self._load_dense_encoder()
+        return encoder.encode_queries([query])[0]
+
+    def encode_documents(self, texts: List[str]) -> np.ndarray:
+        encoder = self._load_dense_encoder()
+        return encoder.encode_documents(texts)
+
+    def get_embedding(self, paper_id: str) -> np.ndarray:
+        return self.dense_embeddings[self.paper_id_to_index[paper_id]]
+
+    def retrieve(self, query: str, k: int = 10) -> List[dict]:
+        return self.retrieve_by_vector(self.encode_query(query), k=k)
+
+    def retrieve_by_vector(self, query_vector: np.ndarray, k: int = 10) -> List[dict]:
+        query_vector = l2_normalize(query_vector)
+        scores = self.dense_embeddings @ query_vector
+        top_idx = np.argsort(scores)[::-1][:k]
+        return self._format_results(top_idx, scores[top_idx])


### PR DESCRIPTION
Closes #6

Implements Stage 3 LLM-based reflective refinement with three feedback modes: rocchio, llm, and combined.

Notes:
- This branch is stacked on top of issue/7 because the Stage 3 retriever uses the new dense-artifact handling from that branch.
- Supports pseudo-feedback, configurable dense backends, and grounded QA through the UM-hosted OpenAI-compatible endpoint.