### PR TITLE
Implement chunk-level evidence selection for stage 3

### DIFF
--- a/run_part3.py
+++ b/run_part3.py
@@ -1,79 +1,213 @@
 import argparse
 from pathlib import Path
-import numpy as np
-from src.retrieval_extended import PaperRetrieverExtended
-from src.part2_utils import load_jsonl
+
 from src.feedback_logic import apply_rocchio
+from src.part2_utils import load_jsonl
 from src.qa_engine import QAGenerator
+from src.retrieval_extended import ChunkRetriever, PaperRetrieverExtended
+
 
 def normalize_id(paper_id: str) -> str:
-    """
-    Standardize ArXiv IDs by removing 'arxiv:' prefix and version suffixes like 'v1'.
-    """
+    """Standardize ArXiv IDs by removing prefix and version suffixes."""
     pid = str(paper_id).lower().strip()
     if pid.startswith("arxiv:"):
         pid = pid.replace("arxiv:", "")
-    if 'v' in pid:
-        pid = pid.split('v')[0]
+    if "v" in pid:
+        pid = pid.split("v")[0]
     return pid
+
+
+def run_feedback_rounds(
+    retriever: PaperRetrieverExtended,
+    query_text: str,
+    relevant_ids: set[str],
+    top_k: int,
+    rounds: int,
+    use_pseudo: bool,
+    retrieval_mode: str,
+    hybrid_alpha: float,
+    dense_candidates: int,
+):
+    current_vec = retriever.encode_query(query_text) if retrieval_mode in {"dense", "hybrid"} else None
+    final_results = []
+
+    for r in range(rounds + 1):
+        if retrieval_mode == "tfidf":
+            results = retriever.retrieve_tfidf(query_text, k=top_k)
+        elif retrieval_mode == "dense":
+            results = retriever.retrieve_by_vector(current_vec, k=top_k)
+        elif retrieval_mode == "hybrid":
+            results = retriever.retrieve_hybrid(
+                query_text,
+                k=top_k,
+                alpha=hybrid_alpha,
+                dense_candidates=dense_candidates,
+            )
+        else:
+            raise ValueError(f"Unsupported retrieval mode: {retrieval_mode}")
+        final_results = results
+
+        hits = [res for res in results if normalize_id(res["arxiv_id"]) in relevant_ids]
+        precision = len(hits) / top_k
+        print(f"Round {r} | {retrieval_mode} Precision@{top_k}: {precision:.2f}")
+
+        if r < rounds:
+            if retrieval_mode != "dense":
+                continue
+            if hits:
+                pos_vecs = [
+                    retriever.dense_embeddings[retriever.paper_ids.index(hit["paper_id"])]
+                    for hit in hits
+                ]
+                current_vec = apply_rocchio(current_vec, pos_vecs)
+                print(f"  --> Vector updated using {len(hits)} relevant papers.")
+            elif use_pseudo and results:
+                print("  --> Applying Pseudo-Feedback using the top-ranked document.")
+                top_1_id = results[0]["paper_id"]
+                top_1_vec = retriever.dense_embeddings[retriever.paper_ids.index(top_1_id)]
+                current_vec = apply_rocchio(current_vec, [top_1_vec])
+
+    if current_vec is None:
+        current_vec = retriever.encode_query(query_text)
+
+    return current_vec, final_results
+
+
+def build_context_results(
+    context_mode: str,
+    paper_results,
+    chunk_retriever: ChunkRetriever,
+    query_text: str,
+    query_vector,
+    token_budget: int,
+    max_chunks: int | None,
+    chunk_score_mode: str,
+):
+    if context_mode == "paper":
+        return paper_results
+
+    paper_ids = [result["paper_id"] for result in paper_results]
+    return chunk_retriever.select_chunks_for_papers(
+        paper_ids=paper_ids,
+        query_text=query_text,
+        query_vector=query_vector,
+        token_budget=token_budget,
+        max_chunks=max_chunks,
+        score_mode=chunk_score_mode,
+    )
+
+
+def describe_context(context_mode: str, context_results) -> str:
+    if context_mode == "paper":
+        return f"{len(context_results)} papers"
+
+    total_tokens = sum(int(item.get("tokens_est", 0)) for item in context_results)
+    return f"{len(context_results)} chunks / ~{total_tokens} tokens"
+
 
 def main():
     parser = argparse.ArgumentParser(description="Part 3: Relevance Feedback & RAG")
     parser.add_argument("--queries", default="data/queries_val.jsonl")
     parser.add_argument("--rounds", type=int, default=1, help="Number of feedback iterations")
-    parser.add_argument("--top_k", type=int, default=5, help="Number of documents to retrieve")
+    parser.add_argument("--top_k", type=int, default=5, help="Number of papers to retrieve")
     parser.add_argument("--use_pseudo", action="store_true", help="Enable PRF if no ground truth is found")
+    parser.add_argument(
+        "--retrieval-mode",
+        choices=["tfidf", "dense", "hybrid"],
+        default="tfidf",
+        help="Paper-level retrieval mode used before chunk selection",
+    )
+    parser.add_argument(
+        "--hybrid-alpha",
+        type=float,
+        default=0.5,
+        help="Interpolation weight for hybrid retrieval",
+    )
+    parser.add_argument(
+        "--dense-candidates",
+        type=int,
+        default=100,
+        help="Dense candidate pool size for hybrid retrieval",
+    )
+    parser.add_argument(
+        "--context-mode",
+        choices=["paper", "chunk"],
+        default="paper",
+        help="Use paper abstracts or chunk-level evidence for the final RAG context",
+    )
+    parser.add_argument(
+        "--compare-context-modes",
+        action="store_true",
+        help="Run both paper and chunk context generation for each query",
+    )
+    parser.add_argument(
+        "--chunk-token-budget",
+        type=int,
+        default=3000,
+        help="Maximum estimated tokens to include in chunk context mode",
+    )
+    parser.add_argument(
+        "--chunk-max-results",
+        type=int,
+        default=None,
+        help="Optional cap on the number of selected chunks",
+    )
+    parser.add_argument(
+        "--chunk-score-mode",
+        choices=["dense", "tfidf"],
+        default="dense",
+        help="How to score candidate chunks within the retrieved papers",
+    )
     args = parser.parse_args()
 
-    # Initialize Retrieval and QA Engine
-    # Reminder: Must be on UM VPN for the GPT-oss-120B server
     retriever = PaperRetrieverExtended()
+    chunk_retriever = ChunkRetriever(paper_retriever=retriever)
     qa_gen = QAGenerator()
     query_rows = load_jsonl(Path(args.queries))
+    context_modes = ["paper", "chunk"] if args.compare_context_modes else [args.context_mode]
 
     print(f"Executing Part 3 evaluation on {len(query_rows)} queries...")
 
     for row in query_rows:
         query_text = row["query_text"]
         relevant_ids = {normalize_id(idx) for idx in row.get("relevant_arxiv_ids", [])}
-        
-        print(f"\n{'='*80}")
+
+        print(f"\n{'=' * 80}")
         print(f"QUERY: {query_text}")
-        print(f"{'='*80}")
-        
-        # 1. Generate initial query vector
-        current_vec = retriever.encode_query(query_text)
-        
-        final_results = []
-        for r in range(args.rounds + 1):
-            # 2. Retrieve papers
-            results = retriever.retrieve_by_vector(current_vec, k=args.top_k)
-            final_results = results
-            
-            # Calculate Precision based on normalized IDs
-            hits = [res for res in results if normalize_id(res['arxiv_id']) in relevant_ids]
-            precision = len(hits) / args.top_k
-            print(f"Round {r} | Precision@{args.top_k}: {precision:.2f}")
+        print(f"{'=' * 80}")
 
-            # 3. Apply Rocchio Feedback Logic
-            if r < args.rounds:
-                if hits:
-                    # Standard Rocchio using ground truth hits
-                    pos_vecs = [retriever.dense_embeddings[retriever.paper_ids.index(h['paper_id'])] for h in hits]
-                    current_vec = apply_rocchio(current_vec, pos_vecs)
-                    print(f"  --> Vector updated using {len(hits)} relevant papers.")
-                elif args.use_pseudo:
-                    # Pseudo-Relevance Feedback (PRF) for demonstration
-                    print(f"  --> Applying Pseudo-Feedback using the top-ranked document.")
-                    top_1_id = results[0]['paper_id']
-                    top_1_vec = retriever.dense_embeddings[retriever.paper_ids.index(top_1_id)]
-                    current_vec = apply_rocchio(current_vec, [top_1_vec])
+        final_query_vector, final_results = run_feedback_rounds(
+            retriever=retriever,
+            query_text=query_text,
+            relevant_ids=relevant_ids,
+            top_k=args.top_k,
+            rounds=args.rounds,
+            use_pseudo=args.use_pseudo,
+            retrieval_mode=args.retrieval_mode,
+            hybrid_alpha=args.hybrid_alpha,
+            dense_candidates=args.dense_candidates,
+        )
 
-        # 4. Generate grounded answer using retrieved context and UM Server
-        print("\n[RAG] Generating answer via UM GPT-oss-120B...")
-        context = qa_gen.format_context(final_results)
-        answer = qa_gen.generate_answer(query_text, context)
-        print(f"\n[AI Answer]:\n{answer}\n")
+        for context_mode in context_modes:
+            context_results = build_context_results(
+                context_mode=context_mode,
+                paper_results=final_results,
+                chunk_retriever=chunk_retriever,
+                query_text=query_text,
+                query_vector=final_query_vector,
+                token_budget=args.chunk_token_budget,
+                max_chunks=args.chunk_max_results,
+                chunk_score_mode=args.chunk_score_mode,
+            )
+
+            print(
+                f"\n[RAG] Generating answer via UM GPT-oss-120B "
+                f"with {context_mode}-level context ({describe_context(context_mode, context_results)})..."
+            )
+            context = qa_gen.format_context(context_results)
+            answer = qa_gen.generate_answer(query_text, context)
+            print(f"\n[AI Answer | {context_mode}]:\n{answer}\n")
+
 
 if __name__ == "__main__":
     main()

--- a/src/qa_engine.py
+++ b/src/qa_engine.py
@@ -1,10 +1,10 @@
 from openai import OpenAI
-from typing import List, Dict
+from typing import Dict, List
+
 
 class QAGenerator:
     def __init__(self):
-        # Initialize OpenAI client with UM server details
-        # Ensure you are on UM VPN to access these URLs
+        # Ensure you are on UM VPN to access this server.
         self.client = OpenAI(
             base_url="http://promaxgb10-d473.eecs.umich.edu:8000/v1",
             api_key="api_IcLlffdxoWOSgBPWW3X3zS15YSBHim5a"
@@ -12,33 +12,44 @@ class QAGenerator:
         self.model_name = "openai/gpt-oss-120b"
 
     def format_context(self, results: List[Dict]) -> str:
-        """Combine retrieved abstracts into a single context string."""
+        """Combine paper abstracts or chunk-level evidence into a single context string."""
         context_blocks = []
         for i, res in enumerate(results):
-            block = f"Source [{i+1}] (ID: {res['arxiv_id']}):\nTitle: {res['title']}\nAbstract: {res['abstract']}"
+            if "chunk_text" in res:
+                block = (
+                    f"Source [{i+1}] (ID: {res['arxiv_id']}, chunk {res.get('chunk_index', '?')}):\n"
+                    f"Title: {res.get('title', '')}\n"
+                    f"Evidence: {res['chunk_text']}"
+                )
+            else:
+                block = (
+                    f"Source [{i+1}] (ID: {res['arxiv_id']}):\n"
+                    f"Title: {res['title']}\n"
+                    f"Abstract: {res['abstract']}"
+                )
             context_blocks.append(block)
         return "\n\n".join(context_blocks)
 
     def generate_answer(self, query: str, context: str) -> str:
-        """Generate a grounded answer using the provided context."""
-        prompt = f"""You are a research assistant. Answer the user's question based ONLY on the provided arXiv abstracts. 
+        """Generate a grounded answer using the provided evidence."""
+        prompt = f"""You are a research assistant. Answer the user's question based ONLY on the provided arXiv evidence.
 If the answer is not in the context, say "I do not have enough information."
 Always cite your sources using [Source X] notation at the end of relevant sentences.
 
 CONTEXT:
 {context}
 
-QUESTION: 
+QUESTION:
 {query}
 
 ANSWER:"""
-        
+
         try:
             response = self.client.chat.completions.create(
                 model=self.model_name,
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=800,
-                temperature=0.1  # Low temperature for factual consistency
+                temperature=0.1,
             )
             return response.choices[0].message.content
         except Exception as e:

--- a/src/retrieval_extended.py
+++ b/src/retrieval_extended.py
@@ -1,26 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Sequence
+
 import numpy as np
-from typing import List, Dict
+
+from src.part2_utils import load_config, load_jsonl
 from src.retrieval import PaperRetriever
-from src.dense_encoder import DenseEncoder
+
 
 class PaperRetrieverExtended(PaperRetriever):
     def retrieve_by_vector(self, query_vector: np.ndarray, k: int = 10) -> List[Dict]:
-        """Search the 384-dim embedding space."""
-        if len(query_vector.shape) == 1:
+        """Search the paper embedding space with a precomputed query vector."""
+        if query_vector.ndim == 1:
             query_vector = query_vector.reshape(1, -1)
-            
-        # This will now work because both will be 384-dim
-        scores = np.dot(self.dense_embeddings, query_vector.T).flatten()
+
+        scores = self.dense_embeddings @ query_vector.T
+        scores = scores.ravel()
         top_k_idx = np.argsort(scores)[::-1][:k]
         return self._format_results(top_k_idx, scores[top_k_idx])
 
     def encode_query(self, query_text: str) -> np.ndarray:
-        """
-        Encodes using MiniLM to match your specific (20000, 384) index.
-        """
-        # We use the model that matches your 'dense_embeddings.npy' shape
-        encoder = DenseEncoder(model_name="sentence-transformers/all-MiniLM-L6-v2")
-        
-        # This will produce a 384-dim vector
-        vector = encoder.encode_queries([query_text])
-        return vector[0]
+        """Encode a query with the same dense model used for paper retrieval."""
+        encoder = self._load_dense_encoder()
+        return encoder.encode_queries([query_text])[0]
+
+
+class ChunkRetriever:
+    def __init__(
+        self,
+        config_path: str = "configs/config.yaml",
+        chunk_path: str | None = None,
+        embeddings_path: str | None = None,
+        paper_retriever: PaperRetriever | None = None,
+    ):
+        cfg = load_config(config_path)
+        data_dir = Path(cfg["data_collection"]["output_path"]).parent
+
+        self.cfg = cfg
+        self.data_dir = data_dir
+        self.chunk_path = Path(chunk_path) if chunk_path else data_dir / "arxiv_chunks.jsonl"
+        self.embeddings_path = Path(embeddings_path) if embeddings_path else data_dir / "chunk_embeddings.npy"
+        self.paper_retriever = paper_retriever or PaperRetriever(config_path=config_path)
+        self.chunks = load_jsonl(self.chunk_path)
+
+        self.chunk_texts = [chunk["chunk_text"] for chunk in self.chunks]
+        self.chunk_by_paper: Dict[str, List[int]] = {}
+        for idx, chunk in enumerate(self.chunks):
+            self.chunk_by_paper.setdefault(chunk["paper_id"], []).append(idx)
+
+        self._chunk_embeddings: np.ndarray | None = None
+        self._chunk_tfidf_matrix = None
+
+    def encode_query(self, query_text: str) -> np.ndarray:
+        return self.paper_retriever.encode_query(query_text)
+
+    def _load_chunk_embeddings(self) -> np.ndarray:
+        if self._chunk_embeddings is not None:
+            return self._chunk_embeddings
+
+        if self.embeddings_path.exists():
+            self._chunk_embeddings = np.load(self.embeddings_path)
+            return self._chunk_embeddings
+
+        encoder = self.paper_retriever._load_dense_encoder()
+        batch_size = int(self.cfg["embeddings"].get("dense_batch_size", 64))
+        chunk_embeddings = encoder.encode_documents(
+            self.chunk_texts,
+            batch_size=batch_size,
+            show_progress_bar=True,
+        )
+        self.embeddings_path.parent.mkdir(parents=True, exist_ok=True)
+        np.save(self.embeddings_path, chunk_embeddings.astype(np.float32))
+        self._chunk_embeddings = chunk_embeddings.astype(np.float32)
+        return self._chunk_embeddings
+
+    def _load_chunk_tfidf_matrix(self):
+        if self._chunk_tfidf_matrix is not None:
+            return self._chunk_tfidf_matrix
+        self._chunk_tfidf_matrix = self.paper_retriever.vectorizer.transform(self.chunk_texts)
+        return self._chunk_tfidf_matrix
+
+    def _score_chunk_subset_dense(
+        self,
+        query_vector: np.ndarray,
+        candidate_indices: Sequence[int],
+    ) -> np.ndarray:
+        if query_vector.ndim > 1:
+            query_vector = query_vector[0]
+        embeddings = self._load_chunk_embeddings()
+        subset = embeddings[np.asarray(candidate_indices)]
+        return subset @ query_vector
+
+    def _score_chunk_subset_tfidf(
+        self,
+        query_text: str,
+        candidate_indices: Sequence[int],
+    ) -> np.ndarray:
+        chunk_matrix = self._load_chunk_tfidf_matrix()
+        query_vec = self.paper_retriever.vectorizer.transform([query_text])
+        return (chunk_matrix[np.asarray(candidate_indices)] @ query_vec.T).toarray().ravel()
+
+    def select_chunks_for_papers(
+        self,
+        paper_ids: Sequence[str],
+        query_text: str,
+        query_vector: np.ndarray | None = None,
+        token_budget: int = 3000,
+        max_chunks: int | None = None,
+        score_mode: str = "dense",
+    ) -> List[Dict]:
+        candidate_indices: List[int] = []
+        for paper_id in paper_ids:
+            candidate_indices.extend(self.chunk_by_paper.get(paper_id, []))
+
+        if not candidate_indices:
+            return []
+
+        if score_mode == "dense":
+            if query_vector is None:
+                query_vector = self.encode_query(query_text)
+            scores = self._score_chunk_subset_dense(query_vector, candidate_indices)
+        elif score_mode == "tfidf":
+            scores = self._score_chunk_subset_tfidf(query_text, candidate_indices)
+        else:
+            raise ValueError(f"Unsupported chunk score mode: {score_mode}")
+
+        ranked_positions = np.argsort(scores)[::-1]
+        selected: List[Dict] = []
+        used_tokens = 0
+
+        for pos in ranked_positions:
+            chunk_idx = candidate_indices[int(pos)]
+            score = float(scores[int(pos)])
+            chunk = self.chunks[chunk_idx]
+            token_count = int(chunk.get("tokens_est", 0))
+
+            if selected and used_tokens + token_count > token_budget:
+                continue
+
+            paper = self.paper_retriever.paper_lookup.get(chunk["paper_id"], {})
+            selected.append(
+                {
+                    "chunk_id": chunk["chunk_id"],
+                    "paper_id": chunk["paper_id"],
+                    "arxiv_id": paper.get("arxiv_id", chunk["paper_id"]),
+                    "title": paper.get("title", ""),
+                    "chunk_text": chunk["chunk_text"],
+                    "chunk_index": chunk.get("chunk_index"),
+                    "chunk_type": chunk.get("chunk_type", "abstract"),
+                    "tokens_est": token_count,
+                    "score": score,
+                }
+            )
+            used_tokens += token_count
+
+            if max_chunks is not None and len(selected) >= max_chunks:
+                break
+            if used_tokens >= token_budget:
+                break
+
+        return selected


### PR DESCRIPTION
Implements chunk-level evidence selection for the Stage 3 RAG pipeline.

Changes:
- add `ChunkRetriever` in `src/retrieval_extended.py`
- support chunk scoring with `dense` and `tfidf`
- support bounded token-budget chunk selection
- update `src/qa_engine.py` to handle both paper-level and chunk-level evidence
- add `--context-mode` / comparison support in `run_part3.py`

Validation:
- ran paper-level vs. chunk-level comparisons on the same queries
- updated default first-stage retrieval to `tfidf` based on validation results