### PR TITLE
[#10] Run full ablation and compile final results tables

### DIFF
--- a/run_ablation.py
+++ b/run_ablation.py
@@ -80,6 +80,20 @@ def run_rocchio_feedback(retriever, query_rows, top_k, rounds):
     return records
 
 
+def run_chunk_retrieval(retriever, query_rows, top_k):
+    records = []
+    for row in query_rows:
+        query_vector = retriever.encode_query(row["query_text"])
+        paper_results = retriever.retrieve_by_vector(query_vector, k=top_k)
+        paper_ids = [r["paper_id"] for r in paper_results]
+        chunk_results = retriever.retrieve_chunks(query_vector, paper_ids, top_m=top_k)
+        predicted_ids = [normalize_id(r["arxiv_id"]) for r in chunk_results]
+        relevant_ids = [normalize_id(i) for i in row.get("relevant_arxiv_ids", [])]
+        metrics = compute_metrics(predicted_ids, relevant_ids, top_k)
+        records.append({"method": "chunk", "round": 0, "query_id": row.get("query_id", ""), **metrics})
+    return records
+
+
 def summarize(records):
     by_method_round = collections.defaultdict(lambda: collections.defaultdict(list))
     for rec in records:
@@ -126,14 +140,16 @@ def main():
 
     if not args.skip_retrieval:
         print("\n[Retrieval] TF-IDF / Dense / Hybrid")
-        retriever2 = PaperRetriever(dense_model_name=args.dense_model)
-        records += run_retrieval_methods(retriever2, query_rows, args.top_k, args.alpha, args.dense_candidates)
+        paper_retriever = PaperRetriever(dense_model_name=args.dense_model)
+        records += run_retrieval_methods(paper_retriever, query_rows, args.top_k, args.alpha, args.dense_candidates)
 
     if not args.skip_feedback:
         print("\n[Feedback] Rocchio relevance feedback")
         dense_model = args.dense_model or "sentence-transformers/all-MiniLM-L6-v2"
-        retriever3 = PaperRetrieverExtended(dense_model_name=dense_model)
-        records += run_rocchio_feedback(retriever3, query_rows, args.top_k, args.rounds)
+        dense_retriever = PaperRetrieverExtended(dense_model_name=dense_model)
+        records += run_rocchio_feedback(dense_retriever, query_rows, args.top_k, args.rounds)
+        print("\n[Chunk] Chunk-level evidence retrieval")
+        records += run_chunk_retrieval(dense_retriever, query_rows, args.top_k)
 
     summarize(records)
 

--- a/run_ablation.py
+++ b/run_ablation.py
@@ -1,0 +1,151 @@
+import argparse
+import collections
+import csv
+from pathlib import Path
+
+import numpy as np
+
+from src.feedback.feedback_logic import apply_rocchio
+from src.retrieval.evaluate import average_precision, ndcg_at_k, precision_at_k, recall_at_k
+from src.retrieval.retrieval import PaperRetriever
+from src.retrieval.retrieval_extended import PaperRetrieverExtended
+from src.utils.helpers import load_jsonl
+
+
+def normalize_id(paper_id: str) -> str:
+    pid = str(paper_id).lower().strip()
+    if pid.startswith("arxiv:"):
+        pid = pid.replace("arxiv:", "")
+    if "v" in pid:
+        pid = pid.split("v")[0]
+    return pid
+
+
+def compute_metrics(predicted_ids, relevant_ids, k):
+    return {
+        "precision": precision_at_k(predicted_ids, relevant_ids, k),
+        "recall": recall_at_k(predicted_ids, relevant_ids, k),
+        "ndcg": ndcg_at_k(predicted_ids, relevant_ids, min(10, k)),
+        "map": average_precision(predicted_ids, relevant_ids),
+    }
+
+
+def run_retrieval_methods(retriever, query_rows, top_k, alpha, dense_candidates):
+    records = []
+    for mode in ["tfidf", "dense", "hybrid"]:
+        print(f"\n  Running {mode.upper()}...")
+        for row in query_rows:
+            if mode == "tfidf":
+                results = retriever.retrieve_tfidf(row["query_text"], k=top_k)
+            elif mode == "dense":
+                results = retriever.retrieve_dense(row["query_text"], k=top_k)
+            else:
+                results = retriever.retrieve_hybrid(
+                    row["query_text"], k=top_k, alpha=alpha, dense_candidates=dense_candidates
+                )
+            predicted_ids = [normalize_id(r["arxiv_id"]) for r in results]
+            relevant_ids = [normalize_id(i) for i in row.get("relevant_arxiv_ids", [])]
+            metrics = compute_metrics(predicted_ids, relevant_ids, top_k)
+            records.append({"method": mode, "round": 0, "query_id": row.get("query_id", ""), **metrics})
+    return records
+
+
+def run_rocchio_feedback(retriever, query_rows, top_k, rounds):
+    records = []
+    for row in query_rows:
+        relevant_ids_norm = {normalize_id(i) for i in row.get("relevant_arxiv_ids", [])}
+        relevant_ids_list = list(relevant_ids_norm)
+        current_vector = retriever.encode_query(row["query_text"])
+
+        for round_idx in range(rounds + 1):
+            results = retriever.retrieve_by_vector(current_vector, k=top_k)
+            predicted_ids = [normalize_id(r["arxiv_id"]) for r in results]
+            metrics = compute_metrics(predicted_ids, relevant_ids_list, top_k)
+            records.append({
+                "method": "rocchio",
+                "round": round_idx,
+                "query_id": row.get("query_id", ""),
+                **metrics,
+            })
+
+            if round_idx >= rounds:
+                break
+
+            hits = [r for r in results if normalize_id(r["arxiv_id"]) in relevant_ids_norm]
+            if not hits:
+                break
+            positive_vectors = [retriever.get_embedding(r["paper_id"]) for r in hits]
+            current_vector = apply_rocchio(current_vector, positive_vectors)
+
+    return records
+
+
+def summarize(records):
+    by_method_round = collections.defaultdict(lambda: collections.defaultdict(list))
+    for rec in records:
+        key = (rec["method"], rec["round"])
+        for m in ("precision", "recall", "ndcg", "map"):
+            by_method_round[key][m].append(rec[m])
+
+    print(f"\n{'=' * 75}")
+    print(f"  {'Method':<18} {'Round':>5} {'P@K':>8} {'R@K':>8} {'NDCG@10':>10} {'MAP':>8}")
+    print(f"  {'-' * 61}")
+    for (method, rnd) in sorted(by_method_round):
+        vals = by_method_round[(method, rnd)]
+        n = len(vals["precision"])
+        print(
+            f"  {method:<18} {rnd:>5} "
+            f"{sum(vals['precision'])/n:>8.3f} "
+            f"{sum(vals['recall'])/n:>8.3f} "
+            f"{sum(vals['ndcg'])/n:>10.3f} "
+            f"{sum(vals['map'])/n:>8.3f}"
+        )
+    print(f"{'=' * 75}\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Full ablation: retrieval methods + Rocchio feedback")
+    parser.add_argument("--queries", default="data/queries_test.jsonl")
+    parser.add_argument("--top-k", type=int, default=10)
+    parser.add_argument("--alpha", type=float, default=0.5)
+    parser.add_argument("--dense-candidates", type=int, default=100)
+    parser.add_argument("--dense-model", default=None)
+    parser.add_argument("--rounds", type=int, choices=[0, 1, 2], default=2)
+    parser.add_argument("--skip-retrieval", action="store_true")
+    parser.add_argument("--skip-feedback", action="store_true")
+    parser.add_argument("--output-csv", default=None)
+    parser.add_argument("--max-queries", type=int, default=None)
+    args = parser.parse_args()
+
+    query_rows = load_jsonl(Path(args.queries))
+    if args.max_queries is not None:
+        query_rows = query_rows[: args.max_queries]
+    print(f"Loaded {len(query_rows)} queries from {args.queries}")
+
+    records = []
+
+    if not args.skip_retrieval:
+        print("\n[Retrieval] TF-IDF / Dense / Hybrid")
+        retriever2 = PaperRetriever(dense_model_name=args.dense_model)
+        records += run_retrieval_methods(retriever2, query_rows, args.top_k, args.alpha, args.dense_candidates)
+
+    if not args.skip_feedback:
+        print("\n[Feedback] Rocchio relevance feedback")
+        dense_model = args.dense_model or "sentence-transformers/all-MiniLM-L6-v2"
+        retriever3 = PaperRetrieverExtended(dense_model_name=dense_model)
+        records += run_rocchio_feedback(retriever3, query_rows, args.top_k, args.rounds)
+
+    summarize(records)
+
+    if args.output_csv and records:
+        csv_path = Path(args.output_csv)
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["method", "round", "query_id", "precision", "recall", "ndcg", "map"])
+            writer.writeheader()
+            writer.writerows(records)
+        print(f"Results written to {csv_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #10 

Add unified ablation script comparing all retrieval and feedback methods

- New `run_ablation.py` comparing TF-IDF, Dense, Hybrid, Rocchio (rounds 0–2), and chunk-level retrieval
- Supports both MiniLM and SPECTER2 via `--dense-model`
- Outputs per-query CSV and averaged summary table

## Ablation Results (Test Set)
```
python run_ablation.py --queries data/queries_test.jsonl --dense-model sentence-transformers/all-MiniLM-L6-v2 --output-csv outputs/ablation_test_minilm.csv
```

### MiniLM (`sentence-transformers/all-MiniLM-L6-v2`)

| Method | Round | P@K | R@K | NDCG@10 | MAP |
|--------|-------|-----|-----|---------|-----|
| TF-IDF | 0 | 0.490 | 0.175 | 0.529 | 0.122 |
| Dense | 0 | 0.557 | 0.201 | 0.596 | 0.155 |
| Hybrid | 0 | 0.619 | 0.224 | 0.652 | 0.177 |
| Chunk | 0 | 0.557 | 0.201 | 0.602 | 0.157 |
| Rocchio | 0 | 0.557 | 0.201 | 0.596 | 0.155 |
| Rocchio | 1 | 0.690 | 0.254 | 0.754 | 0.227 |
| Rocchio | 2 | 0.735 | 0.276 | 0.800 | 0.259 |

### SPECTER2 (`allenai/specter2_base`)
```
python run_ablation.py --queries data/queries_test.jsonl --dense-model allenai/specter2_base --output-csv outputs/ablation_test_specter2.csv           
```

| Method | Round | P@K | R@K | NDCG@10 | MAP |
|--------|-------|-----|-----|---------|-----|
| TF-IDF | 0 | 0.490 | 0.175 | 0.529 | 0.122 |
| Dense | 0 | 0.362 | 0.124 | 0.402 | 0.082 |
| Hybrid | 0 | 0.495 | 0.175 | 0.557 | 0.140 |
| Chunk | 0 | 0.362 | 0.124 | 0.408 | 0.084 |
| Rocchio | 0 | 0.362 | 0.124 | 0.402 | 0.082 |
| Rocchio | 1 | 0.505 | 0.173 | 0.605 | 0.152 |
| Rocchio | 2 | 0.558 | 0.189 | 0.658 | 0.175 |

## Key Findings

1. **Relevance feedback consistently outperforms static retrieval.** MiniLM Rocchio round 2 (NDCG@10=0.800) improves over the best static method, Hybrid (NDCG@10=0.652), by +22.7%. A single round of feedback (round 1) already surpasses Hybrid, showing that even minimal user signal is highly valuable.

2. **Hybrid reranking beats dense-only retrieval.** Combining dense candidate generation with TF-IDF reranking (Hybrid) outperforms pure Dense across all metrics for both encoders, confirming that sparse and dense signals are complementary.

3. **MiniLM outperforms SPECTER2 on this task.** Despite SPECTER2 being a scientific-domain encoder, MiniLM achieves substantially higher scores (Dense NDCG@10: 0.596 vs 0.402). This suggests that for natural-language queries over paper abstracts, general-purpose sentence encoders handle query-document asymmetry better than domain-specific models trained on paper-paper similarity.

4. **TF-IDF beats SPECTER2 dense retrieval.** A sparse baseline (NDCG@10=0.529) outperforms SPECTER2 dense (0.402), further supporting that SPECTER2's training objective does not align well with keyword-heavy user queries.

5. **Chunk-level retrieval matches dense at the paper level.** Chunk retrieval achieves the same P@K and R@K as dense (expected, since it uses the same initial paper retrieval), with a marginal MAP improvement, indicating that chunk selection surfaces relevant content at slightly better ranking positions.